### PR TITLE
Check if the items' product actually exist.

### DIFF
--- a/Helper/OrderData.php
+++ b/Helper/OrderData.php
@@ -137,8 +137,12 @@ class OrderData extends AbstractHelper
         foreach ($items as $item) {
             $product = $item->getProduct();
 
+            if (empty($product)) {
+                continue;
+            }
+
             $image_url = '';
-            if (!empty($product) && $product->getThumbnail() != 'no_selection') {
+            if ($product->getThumbnail() != 'no_selection') {
                 $store = $order->getStore();
                 $baseUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA);
                 $imageUrl = $baseUrl . 'catalog/product' . $product->getImage();

--- a/Helper/OrderData.php
+++ b/Helper/OrderData.php
@@ -138,7 +138,7 @@ class OrderData extends AbstractHelper
             $product = $item->getProduct();
 
             $image_url = '';
-            if ($product->getThumbnail() != 'no_selection') {
+            if (!empty($product) && $product->getThumbnail() != 'no_selection') {
                 $store = $order->getStore();
                 $baseUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA);
                 $imageUrl = $baseUrl . 'catalog/product' . $product->getImage();


### PR DESCRIPTION
It can occur that $item->getProduct() returns a null. This will lead to a fatal error in function getProductsData().