### PR TITLE
command line > set configuration value "ekomiintegration/general/active"

### DIFF
--- a/Model/Validate.php
+++ b/Model/Validate.php
@@ -101,6 +101,10 @@ class Validate extends \Magento\Framework\App\Config\Value
      */
     public function beforeSave()
     {
+        if($this->isCommandLine()) {
+            return parent::beforeSave();
+        }
+        
         $postData = $this->request->getPostValue();
         $postValues = $postData['groups']['general']['fields'];
         $storeId = $this->request->getParam('store', 0);
@@ -131,6 +135,14 @@ class Validate extends \Magento\Framework\App\Config\Value
 
             return parent::beforeSave();
         }
+    }
+
+    /**
+     * Detect command line call.
+     * @return void
+     */
+    public function isCommandLine() {
+        return 'bin/magento' === $this->request->getServerValue('_');
     }
 
     /**


### PR DESCRIPTION
example: "bin/magento config:set ekomiintegration/general/active 1"
result: "Notice: Undefined index: groups in vendor/ekomiltd/ekomiintegration/Model/Validate.php on line 109"
tested on: 2.4.3-p2
solution: Skip the validations if the call comes from the command line.