### PR TITLE
Fix compatibility with php81

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -93,7 +93,7 @@ class Data extends AbstractHelper
      */
     public function getOrderStatus($storeId = false)
     {
-        return $this->getConfigValue(
+        return (string)$this->getConfigValue(
             self::XML_PATH_ORDER_STATUS,
             $storeId
         );


### PR DESCRIPTION
In class \Ekomi\EkomiIntegration\Observer\SendOrderToEkomi at line 59, there is explode() method. The second parameter returns null by default. It throws a fatal error on PHP8.1